### PR TITLE
Fix "Could not find ffi-1.9.3 in any of the sources" error

### DIFF
--- a/lib/ffi-rzmq-core/libzmq.rb
+++ b/lib/ffi-rzmq-core/libzmq.rb
@@ -13,6 +13,9 @@ module LibZMQ
     local_path = FFI::Platform::IS_WINDOWS ? ENV['PATH'].split(';') : ENV['PATH'].split(':')
     homebrew_path = nil
 
+    # RUBYOPT set by RVM breaks 'brew' so we need to unset it.
+    rubyopt = ENV.delete('RUBYOPT')
+
     begin
       stdout, stderr, status = Open3.capture3("brew", "--prefix")
       homebrew_path  = if status.success?
@@ -23,6 +26,9 @@ module LibZMQ
     rescue
       # Homebrew doesn't exist
     end
+
+    # Restore RUBYOPT after executing 'brew' above.
+    ENV['RUBYOPT'] = rubyopt
 
     # Search for libzmq in the following order...
     ZMQ_LIB_PATHS = ([inside_gem] + local_path + [


### PR DESCRIPTION
This pull request fixes the following error message when requiring ffi-rzmq (or ffi-rzmq-core):

```
/Users/chad/.rvm/gems/ruby-2.1.1/gems/bundler-1.3.6/lib/bundler/spec_set.rb:92:in `materialize': Could not find ffi-1.9.3 in any of the sources (Bundler::GemNotFound)
    from /Users/chad/.rvm/gems/ruby-2.1.1/gems/bundler-1.3.6/lib/bundler/spec_set.rb:85:in `map!'
    from /Users/chad/.rvm/gems/ruby-2.1.1/gems/bundler-1.3.6/lib/bundler/spec_set.rb:85:in `materialize'
    from /Users/chad/.rvm/gems/ruby-2.1.1/gems/bundler-1.3.6/lib/bundler/definition.rb:114:in `specs'
    from /Users/chad/.rvm/gems/ruby-2.1.1/gems/bundler-1.3.6/lib/bundler/definition.rb:159:in `specs_for'
    from /Users/chad/.rvm/gems/ruby-2.1.1/gems/bundler-1.3.6/lib/bundler/definition.rb:148:in `requested_specs'
    from /Users/chad/.rvm/gems/ruby-2.1.1/gems/bundler-1.3.6/lib/bundler/environment.rb:18:in `requested_specs'
    from /Users/chad/.rvm/gems/ruby-2.1.1/gems/bundler-1.3.6/lib/bundler/runtime.rb:13:in `setup'
    from /Users/chad/.rvm/gems/ruby-2.1.1/gems/bundler-1.3.6/lib/bundler.rb:119:in `setup'
    from /Users/chad/.rvm/gems/ruby-2.1.1/gems/bundler-1.3.6/lib/bundler/setup.rb:17
```

The error is 100% reproducible for me with the following simple Gemfile and script:

Gemfile:

```
source 'http://rubygems.org'
gem 'ffi-rzmq', '2.0.1'
```

Script:

```
require 'rubygems'
require 'bundler/setup'
require 'ffi-rzmq'
puts "Hello World"
```

The error occurs in the "brew --prefix" subprocess because of the RUBYOPT environment. variable.  These commits unset this variable before executing the subprocess and restores it after.  The commits also capture stderr so that if it were to print other errors then they won't get displayed to the user and cause confusion.
