### PR TITLE
Correct the message memory allocation for libzmq 4.1+

### DIFF
--- a/lib/ffi-rzmq-core/structures.rb
+++ b/lib/ffi-rzmq-core/structures.rb
@@ -3,19 +3,14 @@ module LibZMQ
   # Used for casting pointers back to the msg_t struct
   #
   class Message < FFI::Struct
-    layout :content,  :pointer,
-      :flags,    :uint8,
-      :vsm_size, :uint8,
-      :vsm_data, [:uint8, 30]
-  end
-  
-  if LibZMQ.version[:major] >= 4 && LibZMQ.version[:minor] > 0
-    
-    # zmq_msg_t was expanded to 64 bytes as of version 4.1.0
-    class Message < FFI::Struct
-      layout :content, :ulong_long
+    if LibZMQ.version[:major] >= 4 && LibZMQ.version[:minor] > 0
+      layout :content,  [:uint8, 64]
+    else
+      layout :content,  :pointer,
+             :flags,    :uint8,
+             :vsm_size, :uint8,
+             :vsm_data, [:uint8, 30]
     end
-    
   end
 
 

--- a/spec/structures_spec.rb
+++ b/spec/structures_spec.rb
@@ -5,7 +5,7 @@ describe LibZMQ do
   if LibZMQ.version4? && LibZMQ.version[:minor] > 0
 
     it "the msg_t struct wrapped in Message is 64 bytes" do
-      LibZMQ::Message.size == 64
+      expect(LibZMQ::Message.size).to be == 64
     end
     
   else


### PR DESCRIPTION
This change fixes seg faults caused by incorrect memory allocation for LibZMQ::Message when using libzmq 4.1+. This change also fixes the spec that allowed the error to be missed in tests for ffi-rzmq-core 1.0.4.  I've run the included tests against libzmq 3.2.5 & 4.1.4 for this change.