### PR TITLE
make ist possible to specify zmq lib path via env variable ZMQ_LIB_PATH

### DIFF
--- a/lib/ffi-rzmq-core/libzmq.rb
+++ b/lib/ffi-rzmq-core/libzmq.rb
@@ -11,6 +11,7 @@ module LibZMQ
     # to the usual system paths
     inside_gem = File.join(File.dirname(__FILE__), '..', '..', 'ext')
     local_path = FFI::Platform::IS_WINDOWS ? ENV['PATH'].split(';') : ENV['PATH'].split(':')
+    env_path = [ ENV['ZMQ_LIB_PATH'] ].compact
     homebrew_path = nil
 
     # RUBYOPT set by RVM breaks 'brew' so we need to unset it.
@@ -31,7 +32,7 @@ module LibZMQ
     ENV['RUBYOPT'] = rubyopt
 
     # Search for libzmq in the following order...
-    ZMQ_LIB_PATHS = ([inside_gem] + local_path + [
+    ZMQ_LIB_PATHS = ([inside_gem] + env_path + local_path + [
                        '/usr/local/lib', '/opt/local/lib', homebrew_path, '/usr/lib64'
     ]).compact.map{|path| "#{path}/libzmq.#{FFI::Platform::LIBSUFFIX}"}
     ffi_lib(ZMQ_LIB_PATHS + %w{libzmq})


### PR DESCRIPTION
Automatic detection of the zmq shared library does not always find
the right version. To solve the problem, we allow the user to specify
the directory in which to find the library.