### PR TITLE
PROBLEM: ffi-rzmq tests crash with malloc errors

### DIFF
--- a/ffi-rzmq-core.gemspec
+++ b/ffi-rzmq-core.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "ffi", ["~> 1.9"]
-  s.add_development_dependency "rspec", ["~> 2.14"]
+  s.add_runtime_dependency "ffi"
+  s.add_development_dependency "rspec"
   s.add_development_dependency "rake"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@ require File.expand_path(
 File.join(File.dirname(__FILE__), %w[.. lib ffi-rzmq-core]))
 
 require 'rspec'
-require 'rspec/autorun'
 
 Dir[File.join(File.dirname(__FILE__), "support", "*.rb")].each do |support|
   require support

--- a/spec/structures_spec.rb
+++ b/spec/structures_spec.rb
@@ -2,23 +2,24 @@ require 'spec_helper'
 
 describe LibZMQ do
 
-  if LibZMQ.version4? && LibZMQ.version[:minor] > 0
+  if LibZMQ.version_number >= 040101
 
     it "the msg_t struct wrapped in Message is 64 bytes" do
       LibZMQ::Message.size == 64
     end
-    
-  else
-    
-    it "wraps the msg_t struct as Message" do
-      message = LibZMQ::Message.new
-  
-      expect(message[:content]).to_not be_nil
-      expect(message[:flags]).to_not be_nil
-      expect(message[:vsm_size]).to_not be_nil
-      expect(message[:vsm_data]).to_not be_nil
+
+  elsif LibZMQ.version_number < 040100
+
+    it "the msg_t struct wrapped in Message is 32 bytes" do
+      LibZMQ::Message.size == 32
     end
-    
+
+  elsif LibZMQ.version_number == 040100
+
+    it "the msg_t struct wrapped in Message is 48 bytes" do
+      LibZMQ::Message.size == 32
+    end
+
   end
 
   it "wraps poll_item_t in a PollItem" do


### PR DESCRIPTION
SOLUTION: change memory layout of class LibZMQ::Message

For some unknown reason, the tests of ffi-rzmq crash when using any libzmq version higher than 4.0.7, even though the number of bytes of the current declaration is correct for 4.1.1+.

I changed the layout to correspond exactly what zmq.h exposes to a C program. This fixed all the crashes of the tests and also my programs running on 4.1.4.

Can you please merge this pull request ans also https://github.com/chuckremes/ffi-rzmq-core/pull/13 and release a new version?
